### PR TITLE
feat: add bird dashboard with maps and charts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,8 @@ class Bird(BaseModel):
     species: str
     loc: str
     date: str
+    lat: float
+    lng: float
 
 @app.get("/birds/rare", response_model=list[Bird])
 async def rare_birds(lat: float, lng: float, radius: int = 25):
@@ -62,6 +64,8 @@ async def rare_birds(lat: float, lng: float, radius: int = 25):
                 species=item.get("comName", "unknown"),
                 loc=item.get("locName", ""),
                 date=item.get("obsDt", ""),
+                lat=item.get("lat", 0.0),
+                lng=item.get("lng", 0.0),
             )
         )
     

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
+import { useJsApiLoader, GoogleMap, Marker } from '@react-google-maps/api'
 import { Button } from '../components/ui/button'
 import { Card } from '../components/ui/card'
+
+const ReactECharts = dynamic(() => import('echarts-for-react'), { ssr: false })
 
 interface Bird {
   species: string
   loc: string
   date: string
+  lat: number
+  lng: number
 }
 
 export default function Page() {
@@ -15,6 +21,11 @@ export default function Page() {
   const [lng, setLng] = useState<number | null>(null)
   const [zip, setZip] = useState('')
   const [birds, setBirds] = useState<Bird[]>([])
+
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
+  })
 
   useEffect(() => {
     if (!lat || !lng) {
@@ -45,8 +56,32 @@ export default function Page() {
     setLng(parseFloat(place.longitude))
   }
 
+  const speciesCounts = birds.reduce((acc, b) => {
+    acc[b.species] = (acc[b.species] || 0) + 1
+    return acc
+  }, {} as Record<string, number>)
+
+  const locationCounts = birds.reduce((acc, b) => {
+    acc[b.loc] = (acc[b.loc] || 0) + 1
+    return acc
+  }, {} as Record<string, number>)
+
+  const speciesOption = {
+    xAxis: { type: 'category', data: Object.keys(speciesCounts) },
+    yAxis: { type: 'value' },
+    series: [{ type: 'bar', data: Object.values(speciesCounts) }],
+  }
+
+  const locationOption = {
+    xAxis: { type: 'category', data: Object.keys(locationCounts) },
+    yAxis: { type: 'value' },
+    series: [{ type: 'bar', data: Object.values(locationCounts) }],
+  }
+
+  const mapCenter = lat && lng ? { lat, lng } : undefined
+
   return (
-    <main className="max-w-2xl mx-auto p-4 space-y-4">
+    <main className="max-w-4xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Rare birds near you</h1>
       <div className="flex gap-2">
         <input
@@ -57,6 +92,26 @@ export default function Page() {
         />
         <Button onClick={handleZip}>Update</Button>
       </div>
+      <div className="font-medium">Found {birds.length} birds</div>
+      {birds.length > 0 && (
+        <div className="grid md:grid-cols-2 gap-4">
+          <Card className="p-2">
+            <ReactECharts option={speciesOption} style={{ height: 300 }} />
+          </Card>
+          <Card className="p-2">
+            <ReactECharts option={locationOption} style={{ height: 300 }} />
+          </Card>
+        </div>
+      )}
+      {isLoaded && mapCenter && (
+        <Card className="p-2">
+          <GoogleMap mapContainerStyle={{ width: '100%', height: '400px' }} center={mapCenter} zoom={8}>
+            {birds.map((b, i) => (
+              <Marker key={i} position={{ lat: b.lat, lng: b.lng }} />
+            ))}
+          </GoogleMap>
+        </Card>
+      )}
       <div className="space-y-2">
         {birds.map((b, i) => (
           <Card key={i}>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,10 @@
   "dependencies": {
     "next": "13.5.6",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "echarts": "5.4.3",
+    "echarts-for-react": "3.0.2",
+    "@react-google-maps/api": "2.19.2"
   },
   "devDependencies": {
     "@types/node": "24.2.0",


### PR DESCRIPTION
## Summary
- expose latitude and longitude from the bird API
- show bird count, species/location charts, and map markers in frontend
- add charting and Google Maps libraries

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Module not found: Can't resolve '@react-google-maps/api')
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895323aca54832587937ee0bb01f7ae