### PR TITLE
feat: modern dashboard with interactive map

### DIFF
--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,10 +1,13 @@
 import { ButtonHTMLAttributes } from 'react'
 
-export function Button({ className = '', ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      className={`px-3 py-2 rounded bg-blue-700 text-white hover:bg-blue-800 ${className}`}
-      {...props}
-    />
-  )
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline'
+}
+
+export function Button({ className = '', variant = 'default', ...props }: Props) {
+  const baseClass =
+    variant === 'outline'
+      ? 'px-3 py-2 rounded border hover:bg-gray-50'
+      : 'px-3 py-2 rounded bg-blue-700 text-white hover:bg-blue-800'
+  return <button className={`${baseClass} ${className}`} {...props} />
 }

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
 
-export function Card({ children }: { children: ReactNode }) {
-  return <div className="p-4 border rounded bg-white shadow-sm">{children}</div>
+export function Card({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return <div className={`p-4 border rounded bg-white shadow-sm ${className}`}>{children}</div>
 }


### PR DESCRIPTION
## Summary
- redesign dashboard with shadcn-style layout and stacked bar charts
- add interactive map markers that filter bird list and show details
- show stock photos for each species and provide clear-selection control

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689535b533008325ba59c5dbd3ac1c3f